### PR TITLE
Add Cypress CLI commands (get, set, list) with format helpers

### DIFF
--- a/ytc/cypress/common.go
+++ b/ytc/cypress/common.go
@@ -91,6 +91,7 @@ func parseValue(s string) (any, error) {
 		if err := json.Unmarshal([]byte(s), &value); err != nil {
 			return s, nil
 		}
+		return foldYSONNodes(value)
 	case "yson":
 		if err := yson.Unmarshal([]byte(s), &value); err != nil {
 			return nil, err
@@ -99,11 +100,100 @@ func parseValue(s string) (any, error) {
 		if err := yaml.Unmarshal([]byte(s), &value); err != nil {
 			return nil, err
 		}
+		return foldYSONNodes(value)
 	default:
 		return nil, fmt.Errorf("unsupported format %q", format)
 	}
 
 	return value, nil
+}
+
+func foldYSONNodes(value any) (any, error) {
+	switch typed := value.(type) {
+	case []any:
+		for i, item := range typed {
+			folded, err := foldYSONNodes(item)
+			if err != nil {
+				return nil, err
+			}
+			typed[i] = folded
+		}
+		return typed, nil
+	case map[string]any:
+		_, hasValue := typed["$value"]
+		_, hasAttrs := typed["$attributes"]
+		if hasValue || hasAttrs {
+			return foldYSONNode(typed, hasValue, hasAttrs)
+		}
+		for key, item := range typed {
+			folded, err := foldYSONNodes(item)
+			if err != nil {
+				return nil, err
+			}
+			typed[key] = folded
+		}
+		return typed, nil
+	case map[any]any:
+		converted := make(map[string]any, len(typed))
+		for key, item := range typed {
+			keyString, ok := key.(string)
+			if !ok {
+				return nil, fmt.Errorf("unsupported non-string map key %v", key)
+			}
+			converted[keyString] = item
+		}
+		return foldYSONNodes(converted)
+	default:
+		return value, nil
+	}
+}
+
+func foldYSONNode(node map[string]any, hasValue, hasAttrs bool) (any, error) {
+	var foldedValue any
+	if hasValue {
+		var err error
+		foldedValue, err = foldYSONNodes(node["$value"])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	attrs := map[string]any(nil)
+	if hasAttrs {
+		attrsMap, err := stringMap(node["$attributes"])
+		if err != nil {
+			return nil, fmt.Errorf("$attributes must be an object: %w", err)
+		}
+		attrs = make(map[string]any, len(attrsMap))
+		for key, item := range attrsMap {
+			folded, err := foldYSONNodes(item)
+			if err != nil {
+				return nil, err
+			}
+			attrs[key] = folded
+		}
+	}
+
+	return &yson.ValueWithAttrs{Attrs: attrs, Value: foldedValue}, nil
+}
+
+func stringMap(value any) (map[string]any, error) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, nil
+	case map[any]any:
+		converted := make(map[string]any, len(typed))
+		for key, item := range typed {
+			keyString, ok := key.(string)
+			if !ok {
+				return nil, fmt.Errorf("unsupported non-string map key %v", key)
+			}
+			converted[keyString] = item
+		}
+		return converted, nil
+	default:
+		return nil, fmt.Errorf("got %T", value)
+	}
 }
 
 func readValue(c *cli.Command) (any, error) {

--- a/ytc/cypress/common.go
+++ b/ytc/cypress/common.go
@@ -120,53 +120,59 @@ func foldYSONAttributes(value any) (any, error) {
 		}
 		return typed, nil
 	case map[string]any:
-		nodeValue, nodeAttrs, isAttributeNode := ysonAttributeFields(typed)
-		if isAttributeNode {
-			foldedValue, err := foldYSONAttributes(nodeValue)
-			if err != nil {
-				return nil, err
-			}
-
-			attrs := map[string]any(nil)
-			if nodeAttrs != nil {
-				attrsMap, err := stringMap(nodeAttrs)
-				if err != nil {
-					return nil, fmt.Errorf("$attributes must be an object: %w", err)
-				}
-				attrs = make(map[string]any, len(attrsMap))
-				for key, item := range attrsMap {
-					folded, err := foldYSONAttributes(item)
-					if err != nil {
-						return nil, err
-					}
-					attrs[key] = folded
-				}
-			}
-
-			return &yson.ValueWithAttrs{Attrs: attrs, Value: foldedValue}, nil
-		}
-
-		for key, item := range typed {
-			folded, err := foldYSONAttributes(item)
-			if err != nil {
-				return nil, err
-			}
-			typed[key] = folded
-		}
-		return typed, nil
+		return foldYSONAttributeMap(typed)
 	case map[any]any:
-		converted := make(map[string]any, len(typed))
-		for key, item := range typed {
-			keyString, ok := key.(string)
-			if !ok {
-				return nil, fmt.Errorf("unsupported non-string map key %v", key)
-			}
-			converted[keyString] = item
-		}
-		return foldYSONAttributes(converted)
+		return foldYSONAttributeMap(typed)
 	default:
 		return value, nil
 	}
+}
+
+func foldYSONAttributeMap[T comparable](node map[T]any) (any, error) {
+	converted, err := stringMap(node)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeValue, nodeAttrs, isAttributeNode := ysonAttributeFields(converted)
+	if !isAttributeNode {
+		return foldYSONAttributeMapValues(converted)
+	}
+
+	foldedValue, err := foldYSONAttributes(nodeValue)
+	if err != nil {
+		return nil, err
+	}
+
+	attrs := map[string]any(nil)
+	if nodeAttrs != nil {
+		attrs, err = stringMap(nodeAttrs)
+		if err != nil {
+			return nil, fmt.Errorf("$attributes must be an object: %w", err)
+		}
+		attrs, err = foldYSONAttributeMapValues(attrs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &yson.ValueWithAttrs{Attrs: attrs, Value: foldedValue}, nil
+}
+
+func foldYSONAttributeMapValues[T comparable](node map[T]any) (map[string]any, error) {
+	converted, err := stringMap(node)
+	if err != nil {
+		return nil, err
+	}
+
+	for key, item := range converted {
+		folded, err := foldYSONAttributes(item)
+		if err != nil {
+			return nil, err
+		}
+		converted[key] = folded
+	}
+	return converted, nil
 }
 
 func ysonAttributeFields(node map[string]any) (any, any, bool) {

--- a/ytc/cypress/common.go
+++ b/ytc/cypress/common.go
@@ -1,0 +1,122 @@
+package cypress
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+	"go.ytsaurus.tech/yt/go/yson"
+	ytsdk "go.ytsaurus.tech/yt/go/yt"
+	"go.ytsaurus.tech/yt/go/yt/ythttp"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	proxy  string
+	format string
+)
+
+// Commands returns the minimal Cypress command set.
+func Commands() []*cli.Command {
+	return []*cli.Command{
+		getCommand(),
+		setCommand(),
+		listCommand(),
+	}
+}
+
+func flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "proxy",
+			Usage:       "YT HTTP proxy; defaults to YT_PROXY when empty",
+			Sources:     cli.EnvVars("YT_PROXY"),
+			Destination: &proxy,
+		},
+		&cli.StringFlag{
+			Name:        "format",
+			Aliases:     []string{"f"},
+			Usage:       "data format: json, yson, or yaml",
+			Value:       "json",
+			Destination: &format,
+		},
+	}
+}
+
+func client() (ytsdk.Client, error) {
+	return ythttp.NewClient(&ytsdk.Config{Proxy: proxy})
+}
+
+func requireArgs(c *cli.Command, n int, usage string) error {
+	if c.Args().Len() != n {
+		return fmt.Errorf("usage: %s", usage)
+	}
+	return nil
+}
+
+func printValue(w io.Writer, v any) error {
+	switch normalizedFormat() {
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(v)
+	case "yson":
+		data, err := yson.MarshalFormat(v, yson.FormatPretty)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(w, string(data))
+		return err
+	case "yaml", "yml":
+		data, err := yaml.Marshal(v)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(data)
+		return err
+	default:
+		return fmt.Errorf("unsupported format %q", format)
+	}
+}
+
+func parseValue(s string) (any, error) {
+	var value any
+	s = strings.TrimSpace(s)
+
+	switch normalizedFormat() {
+	case "json":
+		if err := json.Unmarshal([]byte(s), &value); err != nil {
+			return s, nil
+		}
+	case "yson":
+		if err := yson.Unmarshal([]byte(s), &value); err != nil {
+			return nil, err
+		}
+	case "yaml", "yml":
+		if err := yaml.Unmarshal([]byte(s), &value); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported format %q", format)
+	}
+
+	return value, nil
+}
+
+func readValue(c *cli.Command) (any, error) {
+	if c.Args().Len() >= 2 {
+		return parseValue(c.Args().Get(1))
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return nil, err
+	}
+	return parseValue(string(data))
+}
+
+func normalizedFormat() string {
+	return strings.ToLower(strings.TrimSpace(format))
+}

--- a/ytc/cypress/common.go
+++ b/ytc/cypress/common.go
@@ -149,13 +149,9 @@ func foldYSONNodes(value any) (any, error) {
 }
 
 func foldYSONNode(node map[string]any, hasValue, hasAttrs bool) (any, error) {
-	var foldedValue any
-	if hasValue {
-		var err error
-		foldedValue, err = foldYSONNodes(node["$value"])
-		if err != nil {
-			return nil, err
-		}
+	foldedValue, err := foldYSONNodeValue(node, hasValue)
+	if err != nil {
+		return nil, err
 	}
 
 	attrs := map[string]any(nil)
@@ -175,6 +171,29 @@ func foldYSONNode(node map[string]any, hasValue, hasAttrs bool) (any, error) {
 	}
 
 	return &yson.ValueWithAttrs{Attrs: attrs, Value: foldedValue}, nil
+}
+
+func foldYSONNodeValue(node map[string]any, hasValue bool) (any, error) {
+	if hasValue {
+		for key := range node {
+			if key != "$value" && key != "$attributes" {
+				return nil, fmt.Errorf("unexpected key %q alongside $value", key)
+			}
+		}
+		return foldYSONNodes(node["$value"])
+	}
+
+	value := make(map[string]any, len(node)-1)
+	for key, item := range node {
+		if key == "$attributes" {
+			continue
+		}
+		value[key] = item
+	}
+	if len(value) == 0 {
+		return nil, nil
+	}
+	return foldYSONNodes(value)
 }
 
 func stringMap(value any) (map[string]any, error) {

--- a/ytc/cypress/common.go
+++ b/ytc/cypress/common.go
@@ -91,7 +91,7 @@ func parseValue(s string) (any, error) {
 		if err := json.Unmarshal([]byte(s), &value); err != nil {
 			return s, nil
 		}
-		return foldYSONNodes(value)
+		return foldYSONAttributes(value)
 	case "yson":
 		if err := yson.Unmarshal([]byte(s), &value); err != nil {
 			return nil, err
@@ -100,7 +100,7 @@ func parseValue(s string) (any, error) {
 		if err := yaml.Unmarshal([]byte(s), &value); err != nil {
 			return nil, err
 		}
-		return foldYSONNodes(value)
+		return foldYSONAttributes(value)
 	default:
 		return nil, fmt.Errorf("unsupported format %q", format)
 	}
@@ -108,11 +108,11 @@ func parseValue(s string) (any, error) {
 	return value, nil
 }
 
-func foldYSONNodes(value any) (any, error) {
+func foldYSONAttributes(value any) (any, error) {
 	switch typed := value.(type) {
 	case []any:
 		for i, item := range typed {
-			folded, err := foldYSONNodes(item)
+			folded, err := foldYSONAttributes(item)
 			if err != nil {
 				return nil, err
 			}
@@ -122,11 +122,37 @@ func foldYSONNodes(value any) (any, error) {
 	case map[string]any:
 		_, hasValue := typed["$value"]
 		_, hasAttrs := typed["$attributes"]
-		if hasValue || hasAttrs {
-			return foldYSONNode(typed, hasValue, hasAttrs)
+		if hasOnlyYSONAttributeKeys(typed, hasValue, hasAttrs) {
+			var foldedValue any
+			if hasValue {
+				var err error
+				foldedValue, err = foldYSONAttributes(typed["$value"])
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			attrs := map[string]any(nil)
+			if hasAttrs {
+				attrsMap, err := stringMap(typed["$attributes"])
+				if err != nil {
+					return nil, fmt.Errorf("$attributes must be an object: %w", err)
+				}
+				attrs = make(map[string]any, len(attrsMap))
+				for key, item := range attrsMap {
+					folded, err := foldYSONAttributes(item)
+					if err != nil {
+						return nil, err
+					}
+					attrs[key] = folded
+				}
+			}
+
+			return &yson.ValueWithAttrs{Attrs: attrs, Value: foldedValue}, nil
 		}
+
 		for key, item := range typed {
-			folded, err := foldYSONNodes(item)
+			folded, err := foldYSONAttributes(item)
 			if err != nil {
 				return nil, err
 			}
@@ -142,58 +168,22 @@ func foldYSONNodes(value any) (any, error) {
 			}
 			converted[keyString] = item
 		}
-		return foldYSONNodes(converted)
+		return foldYSONAttributes(converted)
 	default:
 		return value, nil
 	}
 }
 
-func foldYSONNode(node map[string]any, hasValue, hasAttrs bool) (any, error) {
-	foldedValue, err := foldYSONNodeValue(node, hasValue)
-	if err != nil {
-		return nil, err
+func hasOnlyYSONAttributeKeys(node map[string]any, hasValue, hasAttrs bool) bool {
+	if !hasValue && !hasAttrs {
+		return false
 	}
-
-	attrs := map[string]any(nil)
-	if hasAttrs {
-		attrsMap, err := stringMap(node["$attributes"])
-		if err != nil {
-			return nil, fmt.Errorf("$attributes must be an object: %w", err)
-		}
-		attrs = make(map[string]any, len(attrsMap))
-		for key, item := range attrsMap {
-			folded, err := foldYSONNodes(item)
-			if err != nil {
-				return nil, err
-			}
-			attrs[key] = folded
+	for key := range node {
+		if key != "$value" && key != "$attributes" {
+			return false
 		}
 	}
-
-	return &yson.ValueWithAttrs{Attrs: attrs, Value: foldedValue}, nil
-}
-
-func foldYSONNodeValue(node map[string]any, hasValue bool) (any, error) {
-	if hasValue {
-		for key := range node {
-			if key != "$value" && key != "$attributes" {
-				return nil, fmt.Errorf("unexpected key %q alongside $value", key)
-			}
-		}
-		return foldYSONNodes(node["$value"])
-	}
-
-	value := make(map[string]any, len(node)-1)
-	for key, item := range node {
-		if key == "$attributes" {
-			continue
-		}
-		value[key] = item
-	}
-	if len(value) == 0 {
-		return nil, nil
-	}
-	return foldYSONNodes(value)
+	return true
 }
 
 func stringMap(value any) (map[string]any, error) {

--- a/ytc/cypress/common.go
+++ b/ytc/cypress/common.go
@@ -120,21 +120,16 @@ func foldYSONAttributes(value any) (any, error) {
 		}
 		return typed, nil
 	case map[string]any:
-		_, hasValue := typed["$value"]
-		_, hasAttrs := typed["$attributes"]
-		if hasOnlyYSONAttributeKeys(typed, hasValue, hasAttrs) {
-			var foldedValue any
-			if hasValue {
-				var err error
-				foldedValue, err = foldYSONAttributes(typed["$value"])
-				if err != nil {
-					return nil, err
-				}
+		nodeValue, nodeAttrs, isAttributeNode := ysonAttributeFields(typed)
+		if isAttributeNode {
+			foldedValue, err := foldYSONAttributes(nodeValue)
+			if err != nil {
+				return nil, err
 			}
 
 			attrs := map[string]any(nil)
-			if hasAttrs {
-				attrsMap, err := stringMap(typed["$attributes"])
+			if nodeAttrs != nil {
+				attrsMap, err := stringMap(nodeAttrs)
 				if err != nil {
 					return nil, fmt.Errorf("$attributes must be an object: %w", err)
 				}
@@ -174,16 +169,23 @@ func foldYSONAttributes(value any) (any, error) {
 	}
 }
 
-func hasOnlyYSONAttributeKeys(node map[string]any, hasValue, hasAttrs bool) bool {
-	if !hasValue && !hasAttrs {
-		return false
-	}
-	for key := range node {
-		if key != "$value" && key != "$attributes" {
-			return false
+func ysonAttributeFields(node map[string]any) (any, any, bool) {
+	switch len(node) {
+	case 1:
+		if value, ok := node["$value"]; ok {
+			return value, nil, true
+		}
+		if attrs, ok := node["$attributes"]; ok {
+			return nil, attrs, true
+		}
+	case 2:
+		value, hasValue := node["$value"]
+		attrs, hasAttrs := node["$attributes"]
+		if hasValue && hasAttrs {
+			return value, attrs, true
 		}
 	}
-	return true
+	return nil, nil, false
 }
 
 func stringMap(value any) (map[string]any, error) {

--- a/ytc/cypress/get.go
+++ b/ytc/cypress/get.go
@@ -1,0 +1,33 @@
+package cypress
+
+import (
+	"context"
+	"os"
+
+	"github.com/urfave/cli/v3"
+	"go.ytsaurus.tech/yt/go/ypath"
+)
+
+func getCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "get",
+		Usage:     "get Cypress node value",
+		ArgsUsage: "<path>",
+		Flags:     flags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			if err := requireArgs(c, 1, "get <path>"); err != nil {
+				return err
+			}
+			yc, err := client()
+			if err != nil {
+				return err
+			}
+
+			var result any
+			if err := yc.GetNode(ctx, ypath.Path(c.Args().Get(0)), &result, nil); err != nil {
+				return err
+			}
+			return printValue(os.Stdout, result)
+		},
+	}
+}

--- a/ytc/cypress/list.go
+++ b/ytc/cypress/list.go
@@ -1,0 +1,33 @@
+package cypress
+
+import (
+	"context"
+	"os"
+
+	"github.com/urfave/cli/v3"
+	"go.ytsaurus.tech/yt/go/ypath"
+)
+
+func listCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "list",
+		Usage:     "list Cypress directory children",
+		ArgsUsage: "<path>",
+		Flags:     flags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			if err := requireArgs(c, 1, "list <path>"); err != nil {
+				return err
+			}
+			yc, err := client()
+			if err != nil {
+				return err
+			}
+
+			var result []string
+			if err := yc.ListNode(ctx, ypath.Path(c.Args().Get(0)), &result, nil); err != nil {
+				return err
+			}
+			return printValue(os.Stdout, result)
+		},
+	}
+}

--- a/ytc/cypress/set.go
+++ b/ytc/cypress/set.go
@@ -1,0 +1,31 @@
+package cypress
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v3"
+	"go.ytsaurus.tech/yt/go/ypath"
+)
+
+func setCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "set",
+		Usage:     "set Cypress node value from JSON argument or stdin",
+		ArgsUsage: "<path> [json-value]",
+		Flags:     flags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			if c.Args().Len() < 1 || c.Args().Len() > 2 {
+				return requireArgs(c, 2, "set <path> [json-value]")
+			}
+			yc, err := client()
+			if err != nil {
+				return err
+			}
+			value, err := readValue(c)
+			if err != nil {
+				return err
+			}
+			return yc.SetNode(ctx, ypath.Path(c.Args().Get(0)), value, nil)
+		},
+	}
+}

--- a/ytc/go.mod
+++ b/ytc/go.mod
@@ -6,4 +6,6 @@ require (
 	github.com/abrander/colorjson v0.0.0-20230613094054-36675efdd74f
 	github.com/go-logr/logr v1.4.3
 	github.com/urfave/cli/v3 v3.10.0
+	go.ytsaurus.tech/yt/go v0.0.33
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/ytc/ytc.go
+++ b/ytc/ytc.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/koct9i/junk/ytc/cypress"
 	"github.com/koct9i/junk/ytc/log"
 )
 
@@ -55,7 +56,7 @@ func main() {
 			}
 			return nil
 		},
-		Commands: []*cli.Command{},
+		Commands: cypress.Commands(),
 	}
 	args := append(strings.Split(os.Args[0], "__"), os.Args[1:]...)
 	if err := command.Run(ctx, args); err != nil {


### PR DESCRIPTION
### Motivation

- Provide a small Cypress subcommand set to read, write and list YT Cypress nodes from the `ytc` CLI. 
- Support multiple data formats (`json`, `yson`, `yaml`) and proxy configuration via flags or `YT_PROXY`. 
- Integrate the Cypress commands into the main CLI so they are available from the top-level binary.

### Description

- Introduces a new `cypress` package with `common.go` that implements flags, client creation (`client`), format normalization/parsing (`normalizedFormat`, `parseValue`), printing (`printValue`) and reading values from args or stdin (`readValue`).
- Adds three commands: `get` (`get.go`) to fetch node values, `set` (`set.go`) to set node values from arg or stdin, and `list` (`list.go`) to list directory children, all using the YT SDK `GetNode`, `SetNode`, and `ListNode` APIs. 
- Updates `go.mod` to add `go.ytsaurus.tech/yt/go` and `gopkg.in/yaml.v3` dependencies required for YT client and YAML handling. 
- Registers the new commands in the main CLI by calling `cypress.Commands()` from `ytc.go`.

### Testing

- Ran `go build ./...` to ensure the project compiles successfully and the new package is included, and the build succeeded. 
- Ran `go test ./...` for the module tests and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a312c258b6483378d4b99e5a09d2b38)