### PR TITLE
Add Cypress CLI subcommands (get, set, list) with JSON/YSON/YAML support

### DIFF
--- a/ytc/cypress/common.go
+++ b/ytc/cypress/common.go
@@ -1,0 +1,219 @@
+package cypress
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+	"go.ytsaurus.tech/yt/go/yson"
+	ytsdk "go.ytsaurus.tech/yt/go/yt"
+	"go.ytsaurus.tech/yt/go/yt/ythttp"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	proxy  string
+	format string
+)
+
+// Commands returns the minimal Cypress command set.
+func Commands() []*cli.Command {
+	return []*cli.Command{
+		getCommand(),
+		setCommand(),
+		listCommand(),
+	}
+}
+
+func flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "proxy",
+			Usage:       "YT HTTP proxy; defaults to YT_PROXY when empty",
+			Sources:     cli.EnvVars("YT_PROXY"),
+			Destination: &proxy,
+		},
+		&cli.StringFlag{
+			Name:        "format",
+			Aliases:     []string{"f"},
+			Usage:       "data format: json, yson, or yaml",
+			Value:       "json",
+			Destination: &format,
+		},
+	}
+}
+
+func client() (ytsdk.Client, error) {
+	return ythttp.NewClient(&ytsdk.Config{Proxy: proxy})
+}
+
+func printValue(w io.Writer, v any) error {
+	switch normalizedFormat() {
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(v)
+	case "yson":
+		data, err := yson.MarshalFormat(v, yson.FormatPretty)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(w, string(data))
+		return err
+	case "yaml", "yml":
+		data, err := yaml.Marshal(v)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(data)
+		return err
+	default:
+		return fmt.Errorf("unsupported format %q", format)
+	}
+}
+
+func parseValue(s string) (any, error) {
+	var value any
+	s = strings.TrimSpace(s)
+
+	switch normalizedFormat() {
+	case "json":
+		if err := json.Unmarshal([]byte(s), &value); err != nil {
+			return s, nil
+		}
+		return foldYSONAttributes(value)
+	case "yson":
+		if err := yson.Unmarshal([]byte(s), &value); err != nil {
+			return nil, err
+		}
+	case "yaml", "yml":
+		if err := yaml.Unmarshal([]byte(s), &value); err != nil {
+			return nil, err
+		}
+		return foldYSONAttributes(value)
+	default:
+		return nil, fmt.Errorf("unsupported format %q", format)
+	}
+
+	return value, nil
+}
+
+func foldYSONAttributes(value any) (any, error) {
+	switch typed := value.(type) {
+	case []any:
+		for i, item := range typed {
+			folded, err := foldYSONAttributes(item)
+			if err != nil {
+				return nil, err
+			}
+			typed[i] = folded
+		}
+		return typed, nil
+	case map[string]any:
+		return foldYSONAttributeMap(typed)
+	case map[any]any:
+		return foldYSONAttributeMap(typed)
+	default:
+		return value, nil
+	}
+}
+
+func foldYSONAttributeMap[T comparable](node map[T]any) (any, error) {
+	nodeValue, nodeAttrs, isAttributeNode := ysonAttributeFields(node)
+	if !isAttributeNode {
+		return foldYSONAttributeMapValues(node)
+	}
+
+	foldedValue, err := foldYSONAttributes(nodeValue)
+	if err != nil {
+		return nil, err
+	}
+
+	attrs := map[string]any(nil)
+	if nodeAttrs != nil {
+		attrs, err = stringMap(nodeAttrs)
+		if err != nil {
+			return nil, fmt.Errorf("$attributes must be an object: %w", err)
+		}
+		attrs, err = foldYSONAttributeMapValues(attrs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &yson.ValueWithAttrs{Attrs: attrs, Value: foldedValue}, nil
+}
+
+func foldYSONAttributeMapValues[T comparable](node map[T]any) (map[string]any, error) {
+	converted, err := stringMap(node)
+	if err != nil {
+		return nil, err
+	}
+
+	for key, item := range converted {
+		folded, err := foldYSONAttributes(item)
+		if err != nil {
+			return nil, err
+		}
+		converted[key] = folded
+	}
+	return converted, nil
+}
+
+func ysonAttributeFields[T comparable](node map[T]any) (any, any, bool) {
+	if len(node) > 2 {
+		return nil, nil, false
+	}
+
+	var value, attrs any
+	matches := 0
+	for key, item := range node {
+		switch any(key) {
+		case "$value":
+			value = item
+			matches++
+		case "$attributes":
+			attrs = item
+			matches++
+		}
+	}
+
+	return value, attrs, len(node) == matches
+}
+
+func stringMap(value any) (map[string]any, error) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, nil
+	case map[any]any:
+		converted := make(map[string]any, len(typed))
+		for key, item := range typed {
+			keyString, ok := key.(string)
+			if !ok {
+				return nil, fmt.Errorf("unsupported non-string map key %v", key)
+			}
+			converted[keyString] = item
+		}
+		return converted, nil
+	default:
+		return nil, fmt.Errorf("got %T", value)
+	}
+}
+
+func readValue(values []string) (any, error) {
+	if len(values) > 0 {
+		return parseValue(values[0])
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return nil, err
+	}
+	return parseValue(string(data))
+}
+
+func normalizedFormat() string {
+	return strings.ToLower(strings.TrimSpace(format))
+}

--- a/ytc/cypress/get.go
+++ b/ytc/cypress/get.go
@@ -1,0 +1,32 @@
+package cypress
+
+import (
+	"context"
+	"os"
+
+	"github.com/urfave/cli/v3"
+	"go.ytsaurus.tech/yt/go/ypath"
+)
+
+func getCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "get",
+		Usage: "get Cypress node value",
+		Arguments: []cli.Argument{
+			&cli.StringArgs{Name: "path", Min: 1, Max: 1},
+		},
+		Flags: flags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			yc, err := client()
+			if err != nil {
+				return err
+			}
+
+			var result any
+			if err := yc.GetNode(ctx, ypath.Path(c.StringArgs("path")[0]), &result, nil); err != nil {
+				return err
+			}
+			return printValue(os.Stdout, result)
+		},
+	}
+}

--- a/ytc/cypress/list.go
+++ b/ytc/cypress/list.go
@@ -1,0 +1,32 @@
+package cypress
+
+import (
+	"context"
+	"os"
+
+	"github.com/urfave/cli/v3"
+	"go.ytsaurus.tech/yt/go/ypath"
+)
+
+func listCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "list Cypress directory children",
+		Arguments: []cli.Argument{
+			&cli.StringArgs{Name: "path", Min: 1, Max: 1},
+		},
+		Flags: flags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			yc, err := client()
+			if err != nil {
+				return err
+			}
+
+			var result []string
+			if err := yc.ListNode(ctx, ypath.Path(c.StringArgs("path")[0]), &result, nil); err != nil {
+				return err
+			}
+			return printValue(os.Stdout, result)
+		},
+	}
+}

--- a/ytc/cypress/set.go
+++ b/ytc/cypress/set.go
@@ -1,0 +1,31 @@
+package cypress
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v3"
+	"go.ytsaurus.tech/yt/go/ypath"
+)
+
+func setCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "set",
+		Usage: "set Cypress node value from argument or stdin",
+		Arguments: []cli.Argument{
+			&cli.StringArgs{Name: "path", Min: 1, Max: 1},
+			&cli.StringArgs{Name: "value", Min: 0, Max: 1},
+		},
+		Flags: flags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			yc, err := client()
+			if err != nil {
+				return err
+			}
+			value, err := readValue(c.StringArgs("value"))
+			if err != nil {
+				return err
+			}
+			return yc.SetNode(ctx, ypath.Path(c.StringArgs("path")[0]), value, nil)
+		},
+	}
+}

--- a/ytc/go.mod
+++ b/ytc/go.mod
@@ -6,4 +6,6 @@ require (
 	github.com/abrander/colorjson v0.0.0-20230613094054-36675efdd74f
 	github.com/go-logr/logr v1.4.3
 	github.com/urfave/cli/v3 v3.10.0
+	go.ytsaurus.tech/yt/go v0.0.33
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/ytc/ytc.go
+++ b/ytc/ytc.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/koct9i/junk/ytc/cypress"
 	"github.com/koct9i/junk/ytc/log"
 )
 
@@ -55,7 +56,7 @@ func main() {
 			}
 			return nil
 		},
-		Commands: []*cli.Command{},
+		Commands: cypress.Commands(),
 	}
 	args := append(strings.Split(os.Args[0], "__"), os.Args[1:]...)
 	if err := command.Run(ctx, args); err != nil {


### PR DESCRIPTION
### Motivation
- Add a minimal Cypress client to interact with YT Cypress nodes from the CLI and support reading/writing node values. 
- Provide flexible input/output formats (`json`, `yson`, `yaml`) and a `proxy` flag for HTTP proxy configuration. 

### Description
- Introduce a new `ytc/cypress` package with `common.go`, `get.go`, `set.go`, and `list.go` implementing `get`, `set`, and `list` subcommands and shared helpers like `client()`, `flags()`, `printValue()`, and `readValue()`. 
- Implement format parsing/printing for JSON, YSON, and YAML, including folding of YSON attribute maps into `yson.ValueWithAttrs` via `foldYSONAttributes()` and helpers. 
- Wire the new commands into the main CLI by calling `cypress.Commands()` from `ytc.go`. 
- Update `go.mod` to add `go.ytsaurus.tech/yt/go` and `gopkg.in/yaml.v3` dependencies. 

### Testing
- Built the repository with `go build ./...` to verify compilation of the new package and dependency changes, and the build completed successfully. 
- No automated unit tests were added for the new functionality in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a312c258b6483378d4b99e5a09d2b38)