### PR TITLE
Add ytc/format package with JSON, YSON, and YAML formats

### DIFF
--- a/ytc/cypress/common.go
+++ b/ytc/cypress/common.go
@@ -2,20 +2,19 @@ package cypress
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
-	"gopkg.in/yaml.v3"
 
 	"go.ytsaurus.tech/yt/go/yson"
 	ytsdk "go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yt/ythttp"
 
 	"github.com/koct9i/junk/ytc/config"
+	dataformat "github.com/koct9i/junk/ytc/format"
 	"github.com/koct9i/junk/ytc/log"
 )
 
@@ -26,54 +25,31 @@ func client(ctx context.Context) (ytsdk.Client, error) {
 }
 
 func printValue(w io.Writer, v any) error {
-	switch config.Format {
-	case "json":
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(v)
-	case "yson":
-		data, err := yson.MarshalFormat(v, yson.FormatPretty)
-		if err != nil {
-			return err
-		}
-		_, err = fmt.Fprintln(w, string(data))
+	format, err := dataformat.Parse(config.Format)
+	if err != nil {
 		return err
-	case "yaml", "yml":
-		data, err := yaml.Marshal(v)
-		if err != nil {
-			return err
-		}
-		_, err = w.Write(data)
-		return err
-	default:
-		return fmt.Errorf("unsupported format %q", config.Format)
 	}
+	return format.NewEncoder(w).Encode(v)
 }
 
 func parseValue(s string) (any, error) {
-	var value any
-	s = strings.TrimSpace(s)
-
-	switch config.Format {
-	case "json":
-		if err := json.Unmarshal([]byte(s), &value); err != nil {
-			return s, nil
-		}
-		return foldYSONAttributes(value)
-	case "yson":
-		if err := yson.Unmarshal([]byte(s), &value); err != nil {
-			return nil, err
-		}
-	case "yaml", "yml":
-		if err := yaml.Unmarshal([]byte(s), &value); err != nil {
-			return nil, err
-		}
-		return foldYSONAttributes(value)
-	default:
-		return nil, fmt.Errorf("unsupported format %q", config.Format)
+	format, err := dataformat.Parse(config.Format)
+	if err != nil {
+		return nil, err
 	}
 
-	return value, nil
+	var value any
+	s = strings.TrimSpace(s)
+	if err := format.NewDecoder(strings.NewReader(s)).Decode(&value); err != nil {
+		if format == dataformat.JSON {
+			return s, nil
+		}
+		return nil, err
+	}
+	if format == dataformat.YSON {
+		return value, nil
+	}
+	return foldYSONAttributes(value)
 }
 
 func foldYSONAttributes(value any) (any, error) {

--- a/ytc/format/format.go
+++ b/ytc/format/format.go
@@ -1,0 +1,92 @@
+// Package format provides a common interface for YT data formats.
+package format
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"go.ytsaurus.tech/yt/go/yson"
+	"gopkg.in/yaml.v3"
+)
+
+// Encoder writes a single value in a data format.
+type Encoder interface {
+	Encode(v any) error
+}
+
+// Decoder reads a single value in a data format.
+type Decoder interface {
+	Decode(v any) error
+}
+
+// Format constructs encoders and decoders for a data format.
+type Format interface {
+	Name() string
+	NewEncoder(w io.Writer) Encoder
+	NewDecoder(r io.Reader) Decoder
+}
+
+type factory struct {
+	name       string
+	newEncoder func(io.Writer) Encoder
+	newDecoder func(io.Reader) Decoder
+}
+
+func (f factory) Name() string { return f.name }
+
+func (f factory) NewEncoder(w io.Writer) Encoder { return f.newEncoder(w) }
+
+func (f factory) NewDecoder(r io.Reader) Decoder { return f.newDecoder(r) }
+
+var (
+	JSON Format = factory{
+		name: "json",
+		newEncoder: func(w io.Writer) Encoder {
+			encoder := json.NewEncoder(w)
+			encoder.SetIndent("", "  ")
+			return encoder
+		},
+		newDecoder: func(r io.Reader) Decoder { return json.NewDecoder(r) },
+	}
+
+	YSON Format = factory{
+		name:       "yson",
+		newEncoder: func(w io.Writer) Encoder { return ysonEncoder{w: w} },
+		newDecoder: func(r io.Reader) Decoder { return yson.NewDecoder(r) },
+	}
+
+	YAML Format = factory{
+		name:       "yaml",
+		newEncoder: func(w io.Writer) Encoder { return yaml.NewEncoder(w) },
+		newDecoder: func(r io.Reader) Decoder { return yaml.NewDecoder(r) },
+	}
+)
+
+// Parse returns the Format selected by name.
+func Parse(name string) (Format, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "json":
+		return JSON, nil
+	case "yson":
+		return YSON, nil
+	case "yaml", "yml":
+		return YAML, nil
+	default:
+		return nil, fmt.Errorf("unsupported format %q", name)
+	}
+}
+
+type ysonEncoder struct {
+	w io.Writer
+}
+
+func (e ysonEncoder) Encode(v any) error {
+	data, err := yson.MarshalFormat(v, yson.FormatPretty)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(e.w, string(data))
+	return err
+}

--- a/ytc/format/format_test.go
+++ b/ytc/format/format_test.go
@@ -1,0 +1,39 @@
+package format
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	for _, name := range []string{"json", "yson", "yaml", "yml"} {
+		if _, err := Parse(name); err != nil {
+			t.Fatalf("Parse(%q) returned error: %v", name, err)
+		}
+	}
+
+	if _, err := Parse("xml"); err == nil {
+		t.Fatal("Parse(\"xml\") succeeded, want error")
+	}
+}
+
+func TestFormatsEncodeDecode(t *testing.T) {
+	formats := []Format{JSON, YSON, YAML}
+	for _, format := range formats {
+		t.Run(format.Name(), func(t *testing.T) {
+			var buf bytes.Buffer
+			input := map[string]any{"key": "value", "number": int64(42)}
+			if err := format.NewEncoder(&buf).Encode(input); err != nil {
+				t.Fatalf("Encode() returned error: %v", err)
+			}
+
+			var output map[string]any
+			if err := format.NewDecoder(&buf).Decode(&output); err != nil {
+				t.Fatalf("Decode() returned error: %v", err)
+			}
+			if output["key"] != "value" {
+				t.Fatalf("decoded key = %v, want value", output["key"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a common interface for YT data formats (encoder/decoder) to consolidate format handling across the codebase.
- Mirror patterns from existing ytsaurus helpers by exposing `Encoder`, `Decoder`, and a `Format` factory abstraction.
- Support the three formats currently used (`json`, `yson`, `yaml`) and allow unified parsing/encoding logic in Cypress commands.

### Description
- Add new package `ytc/format` which defines `Encoder`, `Decoder`, and `Format` interfaces and a `Parse` function for format lookup.
- Provide concrete format factories `JSON`, `YSON`, and `YAML` with `NewEncoder`/`NewDecoder` constructors and a `ysonEncoder` that pretty-prints YSON using `yson.MarshalFormat`.
- Refactor `cypress/common.go` to use `dataformat.Parse(config.Format)` and construct encoders/decoders via the new `Format` interface, preserving JSON fallback behavior and YSON attribute folding.
- Add unit tests in `format/format_test.go` covering `Parse` variants and encode/decode round trips for `JSON`, `YSON`, and `YAML`.

### Testing
- Ran `go test ./format`, which passed (`ok`).
- Ran `timeout 120s go test ./...`, which completed successfully (format tests ran and other packages reported no test files or cached results).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39108bb6588337aead53e789293d76)