### PR TITLE
Add parameterized Format support and configurable YSON/JSON/YAML encoders

### DIFF
--- a/ytc/cypress/common.go
+++ b/ytc/cypress/common.go
@@ -41,12 +41,12 @@ func parseValue(s string) (any, error) {
 	var value any
 	s = strings.TrimSpace(s)
 	if err := format.NewDecoder(strings.NewReader(s)).Decode(&value); err != nil {
-		if format == dataformat.JSON {
+		if format.Name() == dataformat.JSON.Name() {
 			return s, nil
 		}
 		return nil, err
 	}
-	if format == dataformat.YSON {
+	if format.Name() == dataformat.YSON.Name() {
 		return value, nil
 	}
 	return foldYSONAttributes(value)

--- a/ytc/format/format.go
+++ b/ytc/format/format.go
@@ -21,69 +21,203 @@ type Decoder interface {
 	Decode(v any) error
 }
 
+// Parameter configures a data format encoder or decoder.
+type Parameter struct {
+	Name  string
+	Value any
+}
+
 // Format constructs encoders and decoders for a data format.
 type Format interface {
 	Name() string
 	NewEncoder(w io.Writer) Encoder
 	NewDecoder(r io.Reader) Decoder
+	WithParameters(...Parameter) (Format, error)
 }
 
-type factory struct {
-	name       string
-	newEncoder func(io.Writer) Encoder
-	newDecoder func(io.Reader) Decoder
+type jsonFormat struct {
+	parameters []Parameter
+	format     string
 }
 
-func (f factory) Name() string { return f.name }
+func (f *jsonFormat) Name() string { return "json" }
 
-func (f factory) NewEncoder(w io.Writer) Encoder { return f.newEncoder(w) }
+func (f *jsonFormat) NewEncoder(w io.Writer) Encoder {
+	encoder := json.NewEncoder(w)
+	if f.format == "pretty" {
+		encoder.SetIndent("", "  ")
+	}
+	return encoder
+}
 
-func (f factory) NewDecoder(r io.Reader) Decoder { return f.newDecoder(r) }
+func (f *jsonFormat) NewDecoder(r io.Reader) Decoder { return json.NewDecoder(r) }
+
+func (f *jsonFormat) WithParameters(parameters ...Parameter) (Format, error) {
+	clone := *f
+	if err := clone.applyParameters(parameters...); err != nil {
+		return nil, err
+	}
+	return &clone, nil
+}
+
+func (f *jsonFormat) applyParameters(parameters ...Parameter) error {
+	f.parameters = append([]Parameter{}, f.parameters...)
+	for _, parameter := range parameters {
+		format, err := parseFormatParameter(parameter)
+		if err != nil {
+			return err
+		}
+		f.format = format
+		f.parameters = append(f.parameters, parameter)
+	}
+	return nil
+}
+
+type ysonFormat struct {
+	parameters []Parameter
+	format     yson.Format
+}
+
+func (f *ysonFormat) Name() string { return "yson" }
+
+func (f *ysonFormat) NewEncoder(w io.Writer) Encoder {
+	return ysonEncoder{w: w, format: f.format}
+}
+
+func (f *ysonFormat) NewDecoder(r io.Reader) Decoder { return yson.NewDecoder(r) }
+
+func (f *ysonFormat) WithParameters(parameters ...Parameter) (Format, error) {
+	clone := *f
+	if err := clone.applyParameters(parameters...); err != nil {
+		return nil, err
+	}
+	return &clone, nil
+}
+
+func (f *ysonFormat) applyParameters(parameters ...Parameter) error {
+	f.parameters = append([]Parameter{}, f.parameters...)
+	for _, parameter := range parameters {
+		format, err := parseFormatParameter(parameter)
+		if err != nil {
+			return err
+		}
+		switch format {
+		case "binary":
+			f.format = yson.FormatBinary
+		case "text":
+			f.format = yson.FormatText
+		case "pretty":
+			f.format = yson.FormatPretty
+		}
+		f.parameters = append(f.parameters, parameter)
+	}
+	return nil
+}
+
+type yamlFormat struct {
+	parameters []Parameter
+	format     string
+}
+
+func (f *yamlFormat) Name() string { return "yaml" }
+
+func (f *yamlFormat) NewEncoder(w io.Writer) Encoder { return yaml.NewEncoder(w) }
+
+func (f *yamlFormat) NewDecoder(r io.Reader) Decoder { return yaml.NewDecoder(r) }
+
+func (f *yamlFormat) WithParameters(parameters ...Parameter) (Format, error) {
+	clone := *f
+	if err := clone.applyParameters(parameters...); err != nil {
+		return nil, err
+	}
+	return &clone, nil
+}
+
+func (f *yamlFormat) applyParameters(parameters ...Parameter) error {
+	f.parameters = append([]Parameter{}, f.parameters...)
+	for _, parameter := range parameters {
+		format, err := parseFormatParameter(parameter)
+		if err != nil {
+			return err
+		}
+		f.format = format
+		f.parameters = append(f.parameters, parameter)
+	}
+	return nil
+}
+
+func parseFormatParameter(parameter Parameter) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(parameter.Name)) {
+	case "format":
+		value, ok := parameter.Value.(string)
+		if !ok {
+			return "", fmt.Errorf("parameter %q must be a string", parameter.Name)
+		}
+		value = strings.ToLower(strings.TrimSpace(value))
+		switch value {
+		case "binary", "text", "pretty":
+			return value, nil
+		default:
+			return "", fmt.Errorf("unsupported format parameter value %q", parameter.Value)
+		}
+	default:
+		return "", fmt.Errorf("unsupported parameter %q", parameter.Name)
+	}
+}
 
 var (
-	JSON Format = factory{
-		name: "json",
-		newEncoder: func(w io.Writer) Encoder {
-			encoder := json.NewEncoder(w)
-			encoder.SetIndent("", "  ")
-			return encoder
-		},
-		newDecoder: func(r io.Reader) Decoder { return json.NewDecoder(r) },
-	}
-
-	YSON Format = factory{
-		name:       "yson",
-		newEncoder: func(w io.Writer) Encoder { return ysonEncoder{w: w} },
-		newDecoder: func(r io.Reader) Decoder { return yson.NewDecoder(r) },
-	}
-
-	YAML Format = factory{
-		name:       "yaml",
-		newEncoder: func(w io.Writer) Encoder { return yaml.NewEncoder(w) },
-		newDecoder: func(r io.Reader) Decoder { return yaml.NewDecoder(r) },
-	}
+	JSON Format = &jsonFormat{format: "pretty"}
+	YSON Format = &ysonFormat{format: yson.FormatPretty}
+	YAML Format = &yamlFormat{format: "text"}
 )
 
-// Parse returns the Format selected by name.
-func Parse(name string) (Format, error) {
-	switch strings.ToLower(strings.TrimSpace(name)) {
+// Parse returns the Format selected by name and applies optional parameters.
+func Parse(name string, parameters ...Parameter) (Format, error) {
+	formatName, nameParameters, err := parseName(name)
+	if err != nil {
+		return nil, err
+	}
+	parameters = append(nameParameters, parameters...)
+
+	var format Format
+	switch strings.ToLower(strings.TrimSpace(formatName)) {
 	case "json":
-		return JSON, nil
+		format = JSON
 	case "yson":
-		return YSON, nil
+		format = YSON
 	case "yaml", "yml":
-		return YAML, nil
+		format = YAML
 	default:
 		return nil, fmt.Errorf("unsupported format %q", name)
 	}
+	return format.WithParameters(parameters...)
+}
+
+type formatName struct {
+	Parameters map[string]any `yson:",attrs"`
+	Name       string         `yson:",value"`
+}
+
+func parseName(name string) (string, []Parameter, error) {
+	var parsed formatName
+	if err := yson.Unmarshal([]byte(strings.TrimSpace(name)), &parsed); err != nil {
+		return "", nil, fmt.Errorf("invalid format name %q: %w", name, err)
+	}
+
+	parameters := make([]Parameter, 0, len(parsed.Parameters))
+	for parameterName, parameterValue := range parsed.Parameters {
+		parameters = append(parameters, Parameter{Name: parameterName, Value: parameterValue})
+	}
+	return parsed.Name, parameters, nil
 }
 
 type ysonEncoder struct {
-	w io.Writer
+	w      io.Writer
+	format yson.Format
 }
 
 func (e ysonEncoder) Encode(v any) error {
-	data, err := yson.MarshalFormat(v, yson.FormatPretty)
+	data, err := yson.MarshalFormat(v, e.format)
 	if err != nil {
 		return err
 	}

--- a/ytc/format/format_test.go
+++ b/ytc/format/format_test.go
@@ -2,11 +2,12 @@ package format
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
 func TestParse(t *testing.T) {
-	for _, name := range []string{"json", "yson", "yaml", "yml"} {
+	for _, name := range []string{"json", "yson", "yaml", "yml", "<format=text>yson"} {
 		if _, err := Parse(name); err != nil {
 			t.Fatalf("Parse(%q) returned error: %v", name, err)
 		}
@@ -14,6 +15,45 @@ func TestParse(t *testing.T) {
 
 	if _, err := Parse("xml"); err == nil {
 		t.Fatal("Parse(\"xml\") succeeded, want error")
+	}
+}
+
+func TestParseParameters(t *testing.T) {
+	format, err := Parse("<format=text>yson", Parameter{Name: "format", Value: "pretty"})
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := format.NewEncoder(&buf).Encode(map[string]any{"key": "value"}); err != nil {
+		t.Fatalf("Encode() returned error: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "\n") {
+		t.Fatalf("encoded YSON = %q, want pretty output", got)
+	}
+}
+
+func TestWithParametersYSONText(t *testing.T) {
+	format, err := YSON.WithParameters(Parameter{Name: "format", Value: "text"})
+	if err != nil {
+		t.Fatalf("WithParameters() returned error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := format.NewEncoder(&buf).Encode(map[string]any{"key": "value"}); err != nil {
+		t.Fatalf("Encode() returned error: %v", err)
+	}
+	if got := buf.String(); strings.Contains(got, "\n    ") {
+		t.Fatalf("encoded YSON = %q, want text output", got)
+	}
+}
+
+func TestWithParametersRejectsInvalidParameter(t *testing.T) {
+	if _, err := YSON.WithParameters(Parameter{Name: "unknown", Value: "text"}); err == nil {
+		t.Fatal("WithParameters() succeeded with unknown parameter, want error")
+	}
+	if _, err := YSON.WithParameters(Parameter{Name: "format", Value: "compact"}); err == nil {
+		t.Fatal("WithParameters() succeeded with invalid format, want error")
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Add the ability to configure data formats with parameters (for example YSON `format=text|pretty|binary` or JSON `pretty`) and parse format names that include attributes like `<format=text>yson`.
- Make encoders/decoders configurable per-format instead of relying on single global format values and update code that compared formats by identity to use names.

### Description
- Introduced `Parameter` and a `WithParameters(...Parameter)` method on the `Format` interface and implemented per-format types `jsonFormat`, `ysonFormat`, and `yamlFormat` with parameter handling.
- Implemented `Parse(name string, parameters ...Parameter)` that supports parsing attribute-annotated names via `parseName` (using `yson.Unmarshal`) and applies parameters via `WithParameters`.
- Added `parseFormatParameter` validation and made `ysonEncoder` respect the configured YSON output `format`, and made the JSON encoder support a `pretty` mode.
- Updated `ytc/cypress/common.go` to compare formats by `format.Name()` rather than by value equality and kept YSON attribute folding logic working with the new abstraction.
- Extended `ytc/format/format_test.go` with tests for parsing parameters, `WithParameters` behavior, and invalid parameter rejection.

### Testing
- Ran the package tests with `go test ./ytc/format`, and all tests in `format_test.go` passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a393b78ec348337bfe883a7d57cd6e0)